### PR TITLE
Ao/fix expiration date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### v0.0.4-master
+- fix: Se corrige error en el seteo de fechas de expiración para el usuario. No se estaba tomando en cuenta el sabado dentro de la validación del currentDate de la reserva (0026365)
+
 ### v0.0.3-master
 - fix: Se agrega conversión de fecha para las estadisticas de ventas recientes. (44872fc)
 

--- a/src/main/java/com/rkmd/toki_no_nagare/service/expiration/CashExpirationService.java
+++ b/src/main/java/com/rkmd/toki_no_nagare/service/expiration/CashExpirationService.java
@@ -37,7 +37,7 @@ public class CashExpirationService extends ExpirationService{
         DayOfWeek currentDay = fixedDate.getDayOfWeek();
 
         ZonedDateTime expirationLimit = fixedDate.with(TemporalAdjusters.next(DayOfWeek.SUNDAY));
-        if (currentDay == DayOfWeek.WEDNESDAY || currentDay == DayOfWeek.THURSDAY || currentDay == DayOfWeek.FRIDAY)
+        if (currentDay == DayOfWeek.WEDNESDAY || currentDay == DayOfWeek.THURSDAY || currentDay == DayOfWeek.FRIDAY || currentDay == DayOfWeek.SATURDAY)
             expirationLimit = expirationLimit.plusWeeks(1);
 
         return expirationLimit;


### PR DESCRIPTION
### v0.0.4-master
- fix: Se corrige error en el seteo de fechas de expiración para el usuario. No se estaba tomando en cuenta el sabado dentro de la validación del currentDate de la reserva (0026365)